### PR TITLE
Enable setting a delay for attribute changes

### DIFF
--- a/R/change.R
+++ b/R/change.R
@@ -9,7 +9,8 @@
 #' @param rate Rate at chich to refresh takes \code{once} refreshes once after all \code{values} have been changed, 
 #'  and \code{iteration} which refreshes at every iteration.
 #' @param refresh Whether to refresh the graph after the change is made.
-#' 
+#' @param delay Optional delay in milliseconds before change is applied. If \code{NULL} (default), no delay.
+#'
 #' @examples
 #' 
 #' library(shiny)
@@ -42,7 +43,8 @@
 #' 
 #' @rdname change
 #' @export
-sg_change_nodes_p <- function(proxy, data, value, attribute, rate = c("once", "iteration"), refresh = TRUE) {
+sg_change_nodes_p <- function(proxy, data, value, attribute, rate = c("once", "iteration"),
+                              refresh = TRUE, delay = NULL) {
 
 	if (!"sigmajsProxy" %in% class(proxy))
 		stop("must pass sigmajsProxy object", call. = FALSE)
@@ -54,7 +56,9 @@ sg_change_nodes_p <- function(proxy, data, value, attribute, rate = c("once", "i
 
 	val <- eval(substitute(value), data) 
 
-	message <- list(id = proxy$id, message = list(rate = rate, value = val, attribute = attribute, refresh = refresh)) # create message
+	message <- list(id = proxy$id,
+	                message = list(rate = rate, value = val, attribute = attribute, refresh = refresh),
+	                delay = delay) # create message
 
 	proxy$session$sendCustomMessage("sg_change_nodes_p", message)
 
@@ -64,7 +68,8 @@ sg_change_nodes_p <- function(proxy, data, value, attribute, rate = c("once", "i
 
 #' @rdname change
 #' @export
-sg_change_edges_p <- function(proxy, data, value, attribute, rate = c("once", "iteration"), refresh = TRUE) {
+sg_change_edges_p <- function(proxy, data, value, attribute, rate = c("once", "iteration"),
+                              refresh = TRUE, delay = NULL) {
 
 	if (!"sigmajsProxy" %in% class(proxy))
 		stop("must pass sigmajsProxy object", call. = FALSE)
@@ -76,7 +81,9 @@ sg_change_edges_p <- function(proxy, data, value, attribute, rate = c("once", "i
 
 	val <- eval(substitute(value), data) 
 
-	message <- list(id = proxy$id, message = list(rate = rate, value = val, attribute = attribute, refresh = refresh)) # create message
+	message <- list(id = proxy$id,
+	                message = list(rate = rate, value = val, attribute = attribute, refresh = refresh),
+	                delay = delay) # create message
 
 	proxy$session$sendCustomMessage("sg_change_edges_p", message)
 

--- a/inst/htmlwidgets/sigmajs.js
+++ b/inst/htmlwidgets/sigmajs.js
@@ -1217,17 +1217,19 @@ if (HTMLWidgets.shinyMode) {
 			var s = get_sigma_graph(message.id);
 			var i = 0;
 			if (typeof s != 'undefined') {
-				s.graph.nodes().forEach((n) => {
-					n[message.message.attribute] = message.message.value[i];
-					if (message.message.refresh === true && message.message.rate === "iteration") {
-						s.refresh();
-					}
-					i = i + 1
-				});
+			  setTimeout(function() {
+  				s.graph.nodes().forEach((n) => {
+  					n[message.message.attribute] = message.message.value[i];
+  					if (message.message.refresh === true && message.message.rate === "iteration") {
+  						s.refresh();
+  					}
+  					i = i + 1
+  				});
 
-				if (message.message.refresh === true && message.message.rate === "once") {
-					s.refresh();
-				}
+  				if (message.message.refresh === true && message.message.rate === "once") {
+  					s.refresh();
+  				}
+			  }, message.delay);
 			}
 		}
 	);
@@ -1237,17 +1239,19 @@ if (HTMLWidgets.shinyMode) {
 			var s = get_sigma_graph(message.id);
 			var i = 0;
 			if (typeof s != 'undefined') {
-				s.graph.edges().forEach((n) => {
-					n[message.message.attribute] = message.message.value[i];
-					if (message.message.refresh === true && message.message.rate === "iteration") {
-						s.refresh();
-					}
-					i = i + 1
-				});
+			  setTimeout(function() {
+  				s.graph.edges().forEach((n) => {
+  					n[message.message.attribute] = message.message.value[i];
+  					if (message.message.refresh === true && message.message.rate === "iteration") {
+  						s.refresh();
+  					}
+  					i = i + 1
+  				});
 
-				if (message.message.refresh === true && message.message.rate === "once") {
-					s.refresh();
-				}
+  				if (message.message.refresh === true && message.message.rate === "once") {
+  					s.refresh();
+  				}
+			  }, message.delay);
 			}
 		}
 	);

--- a/man/change.Rd
+++ b/man/change.Rd
@@ -11,7 +11,8 @@ sg_change_nodes_p(
   value,
   attribute,
   rate = c("once", "iteration"),
-  refresh = TRUE
+  refresh = TRUE,
+  delay = NULL
 )
 
 sg_change_edges_p(
@@ -20,7 +21,8 @@ sg_change_edges_p(
   value,
   attribute,
   rate = c("once", "iteration"),
-  refresh = TRUE
+  refresh = TRUE,
+  delay = NULL
 )
 }
 \arguments{
@@ -36,6 +38,8 @@ sg_change_edges_p(
 and \code{iteration} which refreshes at every iteration.}
 
 \item{refresh}{Whether to refresh the graph after the change is made.}
+
+\item{delay}{Optional delay in milliseconds before change is applied. If \code{NULL} (default), no delay.}
 }
 \description{
 Change nodes and edges attributes on the fly


### PR DESCRIPTION
For building dynamic visualizations, it is helpful to be able to set a certain delay on the attribute change of nodes and/or edges. For example, one can first animate a fade-out of nodes and then hide them after animation is finished.