### PR TITLE
Neighbor highlighting via mouseover and click at the same time 

### DIFF
--- a/R/neighbours.R
+++ b/R/neighbours.R
@@ -7,7 +7,8 @@
 #' @param nodes,edges Color of nodes and edges
 #' @param on The sigmajs event on which to trigger the neighbours highlighting.
 #'   'clickNode' (default) means when a node is clicked on. 'overNode' means
-#'   when mouse is hovering on a node.
+#'   when mouse is hovering on a node. 'clickNode|overNode' means a combination
+#'   of the two modes at the same time.
 #' 
 #' @examples 
 #' nodes <- sg_make_nodes() 
@@ -23,7 +24,7 @@
 #'
 #' @rdname neighbours
 #' @export
-sg_neighbours <- function(sg, nodes = "#eee", edges = "#eee", on = c("clickNode", "overNode")){
+sg_neighbours <- function(sg, nodes = "#eee", edges = "#eee", on = c("clickNode", "overNode", "clickNode|overNode")){
   
   if(missing(sg))
     stop("must pass sg", call. = FALSE)
@@ -47,7 +48,7 @@ sg_neighbors <- sg_neighbours
 
 #' @rdname neighbours
 #' @export
-sg_neighbours_p <- function(proxy, nodes = "#eee", edges = "#eee", on = c("clickNode", "overNode")){
+sg_neighbours_p <- function(proxy, nodes = "#eee", edges = "#eee", on = c("clickNode", "overNode", "clickNode|overNode")){
 
   .test_proxy(proxy)
   on <- match.arg(on)

--- a/inst/htmlwidgets/sigmajs.js
+++ b/inst/htmlwidgets/sigmajs.js
@@ -91,9 +91,21 @@ HTMLWidgets.widget({
           s.graph.edges().forEach(function(e) {
             e.originalColor = e.color;
           });
-          s.bind(x.neighbours.on, function(e) {
-            var nodeId = e.data.node.id,
-                toKeep = s.graph.neighbors(nodeId);
+          x.clickedNodeId = null;
+          // x.neighbours.on can be "clickNode", "overNode" or "clickNode|overNode",
+          // which means neighbour highlighting is triggered by both click and hover.
+          // Bind on all events provided, potentially separated by "|":
+          x.neighbours.on.split("|").forEach(function(on) {
+						s.bind(on, function(e) {
+              if (on == "overNode" && x.clickedNodeId !== null) {
+                // do not highlight another hovered node, we are locked at x.clickedNodeId by user clicking
+                return;
+              }
+              var nodeId = e.data.node.id;
+              if (on == "clickNode") {
+                x.clickedNodeId = nodeId; // lock highlighting at this node by setting x.clickedNodeId
+              }
+              var toKeep = s.graph.neighbors(nodeId);
             toKeep[nodeId] = e.data.node;
             sel_handle.set(nodeId);
             s.graph.nodes().forEach(function(n) {
@@ -110,7 +122,17 @@ HTMLWidgets.widget({
             });
             s.refresh();
           });
-          s.bind(x.neighbours.on == "overNode" ? "outNode" : "clickStage", function(e) {
+          });
+          x.neighbours.on.split("|").forEach(function(on) {
+            on = on == "overNode" ? "outNode" : "clickStage";
+            s.bind(on, function(e) {
+              if (on == "outNode" && x.clickedNodeId !== null) {
+                // do not stop highlighting on mouse out, we are locked into highlighting by user clicking
+                return;
+              }
+              if (on == "clickStage") {
+                x.clickedNodeId = null; // stop locking of highlighting
+              }
             s.graph.nodes().forEach(function(n) {
               n.color = n.originalColor;
             });
@@ -119,6 +141,7 @@ HTMLWidgets.widget({
             });
             s.refresh();
             sel_handle.clear();
+          });
           });
 				}
 				
@@ -1450,9 +1473,21 @@ if (HTMLWidgets.shinyMode) {
 				s.graph.edges().forEach(function(e) {
 					e.originalColor = e.color;
 				});
-				s.bind(message.on, function(e) {
-					var nodeId = e.data.node.id,
-							toKeep = s.graph.neighbors(nodeId);
+				x.clickedNodeId = null;
+				// message.on can be "clickNode", "overNode" or "clickNode|overNode",
+				// which means neighbour highlighting is triggered by both click and hover.
+				// Bind on all events provided, potentially separated by "|":
+				message.on.split("|").forEach(function(on) {
+					s.bind(on, function(e) {
+						if (on == "overNode" && x.clickedNodeId !== null) {
+							// do not highlight another hovered node, we are locked at x.clickedNodeId by user clicking
+							return;
+						}
+						var nodeId = e.data.node.id;
+						if (on == "clickNode") {
+							x.clickedNodeId = nodeId; // lock highlighting at this node by setting x.clickedNodeId
+						}
+						var toKeep = s.graph.neighbors(nodeId);
 					toKeep[nodeId] = e.data.node;
 					s.graph.nodes().forEach(function(n) {
 						if (toKeep[n.id])
@@ -1468,7 +1503,17 @@ if (HTMLWidgets.shinyMode) {
 					});
 					s.refresh();
 				});
-				s.bind(message.on == "overNode" ? "outNode" : "clickStage", function(e) {
+				});
+				message.on.split("|").forEach(function(on) {
+					on = on == "overNode" ? "outNode" : "clickStage";
+					s.bind(on, function(e) {
+						if (on == "outNode" && x.clickedNodeId !== null) {
+							// do not stop highlighting on mouse out, we are locked into highlighting by user clicking
+							return;
+						}
+						if (on == "clickStage") {
+							x.clickedNodeId = null; // stop locking of highlighting
+						}
 					s.graph.nodes().forEach(function(n) {
 						n.color = n.originalColor;
 					});
@@ -1476,6 +1521,7 @@ if (HTMLWidgets.shinyMode) {
 						e.color = e.originalColor;
 					});
 					s.refresh();
+				});
 				});
 
 			}

--- a/inst/htmlwidgets/sigmajs.js
+++ b/inst/htmlwidgets/sigmajs.js
@@ -96,7 +96,7 @@ HTMLWidgets.widget({
           // which means neighbour highlighting is triggered by both click and hover.
           // Bind on all events provided, potentially separated by "|":
           x.neighbours.on.split("|").forEach(function(on) {
-						s.bind(on, function(e) {
+            s.bind(on, function(e) {
               if (on == "overNode" && clickedNodeId !== null) {
                 // do not highlight another hovered node, we are locked at clickedNodeId by user clicking
                 return;
@@ -106,22 +106,22 @@ HTMLWidgets.widget({
                 clickedNodeId = nodeId; // lock highlighting at this node by setting clickedNodeId
               }
               var toKeep = s.graph.neighbors(nodeId);
-            toKeep[nodeId] = e.data.node;
-            sel_handle.set(nodeId);
-            s.graph.nodes().forEach(function(n) {
-              if (toKeep[n.id])
-                n.color = n.originalColor;
-              else
-                n.color = x.neighbours.nodes;
+              toKeep[nodeId] = e.data.node;
+              sel_handle.set(nodeId);
+              s.graph.nodes().forEach(function(n) {
+                if (toKeep[n.id])
+                  n.color = n.originalColor;
+                else
+                  n.color = x.neighbours.nodes;
+              });
+              s.graph.edges().forEach(function(e) {
+                if (toKeep[e.source] && toKeep[e.target])
+                  e.color = e.originalColor;
+                else
+                  e.color = x.neighbours.edges;
+              });
+              s.refresh();
             });
-            s.graph.edges().forEach(function(e) {
-              if (toKeep[e.source] && toKeep[e.target])
-                e.color = e.originalColor;
-              else
-                e.color = x.neighbours.edges;
-            });
-            s.refresh();
-          });
           });
           x.neighbours.on.split("|").forEach(function(on) {
             on = on == "overNode" ? "outNode" : "clickStage";
@@ -1478,50 +1478,50 @@ if (HTMLWidgets.shinyMode) {
 				// which means neighbour highlighting is triggered by both click and hover.
 				// Bind on all events provided, potentially separated by "|":
 				message.on.split("|").forEach(function(on) {
-					s.bind(on, function(e) {
-						if (on == "overNode" && clickedNodeId !== null) {
-							// do not highlight another hovered node, we are locked at clickedNodeId by user clicking
-							return;
-						}
-						var nodeId = e.data.node.id;
-						if (on == "clickNode") {
-							clickedNodeId = nodeId; // lock highlighting at this node by setting clickedNodeId
-						}
-						var toKeep = s.graph.neighbors(nodeId);
-					toKeep[nodeId] = e.data.node;
-					s.graph.nodes().forEach(function(n) {
-						if (toKeep[n.id])
-							n.color = n.originalColor;
-						else
-							n.color = message.nodes;
-					});
-					s.graph.edges().forEach(function(e) {
-						if (toKeep[e.source] && toKeep[e.target])
-							e.color = e.originalColor;
-						else
-							e.color = message.edges;
-					});
-					s.refresh();
+          s.bind(on, function(e) {
+            if (on == "overNode" && clickedNodeId !== null) {
+              // do not highlight another hovered node, we are locked at clickedNodeId by user clicking
+              return;
+            }
+            var nodeId = e.data.node.id;
+            if (on == "clickNode") {
+				  	  clickedNodeId = nodeId; // lock highlighting at this node by setting clickedNodeId
+            }
+            var toKeep = s.graph.neighbors(nodeId);
+				  	toKeep[nodeId] = e.data.node;
+				  	s.graph.nodes().forEach(function(n) {
+				  		if (toKeep[n.id])
+				  			n.color = n.originalColor;
+				  		else
+				  			n.color = message.nodes;
+				  	});
+				  	s.graph.edges().forEach(function(e) {
+				  		if (toKeep[e.source] && toKeep[e.target])
+				  			e.color = e.originalColor;
+				  		else
+				  			e.color = message.edges;
+				  	});
+				  	s.refresh();
+				  });
 				});
-				});
-				message.on.split("|").forEach(function(on) {
-					on = on == "overNode" ? "outNode" : "clickStage";
-					s.bind(on, function(e) {
-						if (on == "outNode" && clickedNodeId !== null) {
-							// do not stop highlighting on mouse out, we are locked into highlighting by user clicking
-							return;
-						}
-						if (on == "clickStage") {
-							clickedNodeId = null; // stop locking of highlighting
-						}
-					s.graph.nodes().forEach(function(n) {
-						n.color = n.originalColor;
-					});
-					s.graph.edges().forEach(function(e) {
-						e.color = e.originalColor;
-					});
-					s.refresh();
-				});
+        message.on.split("|").forEach(function(on) {
+				  on = on == "overNode" ? "outNode" : "clickStage";
+				  s.bind(on, function(e) {
+					  if (on == "outNode" && clickedNodeId !== null) {
+					    // do not stop highlighting on mouse out, we are locked into highlighting by user clicking
+					    return;
+					  }
+					  if (on == "clickStage") {
+					    clickedNodeId = null; // stop locking of highlighting
+					  }
+					  s.graph.nodes().forEach(function(n) {
+						  n.color = n.originalColor;
+					  });
+					  s.graph.edges().forEach(function(e) {
+						  e.color = e.originalColor;
+					  });
+					  s.refresh();
+          });
 				});
 
 			}

--- a/inst/htmlwidgets/sigmajs.js
+++ b/inst/htmlwidgets/sigmajs.js
@@ -91,19 +91,19 @@ HTMLWidgets.widget({
           s.graph.edges().forEach(function(e) {
             e.originalColor = e.color;
           });
-          x.clickedNodeId = null;
+          var clickedNodeId = null;
           // x.neighbours.on can be "clickNode", "overNode" or "clickNode|overNode",
           // which means neighbour highlighting is triggered by both click and hover.
           // Bind on all events provided, potentially separated by "|":
           x.neighbours.on.split("|").forEach(function(on) {
 						s.bind(on, function(e) {
-              if (on == "overNode" && x.clickedNodeId !== null) {
-                // do not highlight another hovered node, we are locked at x.clickedNodeId by user clicking
+              if (on == "overNode" && clickedNodeId !== null) {
+                // do not highlight another hovered node, we are locked at clickedNodeId by user clicking
                 return;
               }
               var nodeId = e.data.node.id;
               if (on == "clickNode") {
-                x.clickedNodeId = nodeId; // lock highlighting at this node by setting x.clickedNodeId
+                clickedNodeId = nodeId; // lock highlighting at this node by setting clickedNodeId
               }
               var toKeep = s.graph.neighbors(nodeId);
             toKeep[nodeId] = e.data.node;
@@ -126,12 +126,12 @@ HTMLWidgets.widget({
           x.neighbours.on.split("|").forEach(function(on) {
             on = on == "overNode" ? "outNode" : "clickStage";
             s.bind(on, function(e) {
-              if (on == "outNode" && x.clickedNodeId !== null) {
+              if (on == "outNode" && clickedNodeId !== null) {
                 // do not stop highlighting on mouse out, we are locked into highlighting by user clicking
                 return;
               }
               if (on == "clickStage") {
-                x.clickedNodeId = null; // stop locking of highlighting
+                clickedNodeId = null; // stop locking of highlighting
               }
             s.graph.nodes().forEach(function(n) {
               n.color = n.originalColor;
@@ -1473,19 +1473,19 @@ if (HTMLWidgets.shinyMode) {
 				s.graph.edges().forEach(function(e) {
 					e.originalColor = e.color;
 				});
-				x.clickedNodeId = null;
+				var clickedNodeId = null;
 				// message.on can be "clickNode", "overNode" or "clickNode|overNode",
 				// which means neighbour highlighting is triggered by both click and hover.
 				// Bind on all events provided, potentially separated by "|":
 				message.on.split("|").forEach(function(on) {
 					s.bind(on, function(e) {
-						if (on == "overNode" && x.clickedNodeId !== null) {
-							// do not highlight another hovered node, we are locked at x.clickedNodeId by user clicking
+						if (on == "overNode" && clickedNodeId !== null) {
+							// do not highlight another hovered node, we are locked at clickedNodeId by user clicking
 							return;
 						}
 						var nodeId = e.data.node.id;
 						if (on == "clickNode") {
-							x.clickedNodeId = nodeId; // lock highlighting at this node by setting x.clickedNodeId
+							clickedNodeId = nodeId; // lock highlighting at this node by setting clickedNodeId
 						}
 						var toKeep = s.graph.neighbors(nodeId);
 					toKeep[nodeId] = e.data.node;
@@ -1507,12 +1507,12 @@ if (HTMLWidgets.shinyMode) {
 				message.on.split("|").forEach(function(on) {
 					on = on == "overNode" ? "outNode" : "clickStage";
 					s.bind(on, function(e) {
-						if (on == "outNode" && x.clickedNodeId !== null) {
+						if (on == "outNode" && clickedNodeId !== null) {
 							// do not stop highlighting on mouse out, we are locked into highlighting by user clicking
 							return;
 						}
 						if (on == "clickStage") {
-							x.clickedNodeId = null; // stop locking of highlighting
+							clickedNodeId = null; // stop locking of highlighting
 						}
 					s.graph.nodes().forEach(function(n) {
 						n.color = n.originalColor;

--- a/inst/htmlwidgets/sigmajs.js
+++ b/inst/htmlwidgets/sigmajs.js
@@ -133,15 +133,15 @@ HTMLWidgets.widget({
               if (on == "clickStage") {
                 clickedNodeId = null; // stop locking of highlighting
               }
-            s.graph.nodes().forEach(function(n) {
-              n.color = n.originalColor;
+              s.graph.nodes().forEach(function(n) {
+                n.color = n.originalColor;
+              });
+              s.graph.edges().forEach(function(e) {
+                e.color = e.originalColor;
+              });
+              s.refresh();
+              sel_handle.clear();
             });
-            s.graph.edges().forEach(function(e) {
-              e.color = e.originalColor;
-            });
-            s.refresh();
-            sel_handle.clear();
-          });
           });
 				}
 				
@@ -1478,16 +1478,16 @@ if (HTMLWidgets.shinyMode) {
 				// which means neighbour highlighting is triggered by both click and hover.
 				// Bind on all events provided, potentially separated by "|":
 				message.on.split("|").forEach(function(on) {
-          s.bind(on, function(e) {
-            if (on == "overNode" && clickedNodeId !== null) {
-              // do not highlight another hovered node, we are locked at clickedNodeId by user clicking
-              return;
-            }
-            var nodeId = e.data.node.id;
-            if (on == "clickNode") {
-				  	  clickedNodeId = nodeId; // lock highlighting at this node by setting clickedNodeId
-            }
-            var toKeep = s.graph.neighbors(nodeId);
+					s.bind(on, function(e) {
+						if (on == "overNode" && clickedNodeId !== null) {
+							// do not highlight another hovered node, we are locked at clickedNodeId by user clicking
+							return;
+						}
+						var nodeId = e.data.node.id;
+						if (on == "clickNode") {
+							clickedNodeId = nodeId; // lock highlighting at this node by setting clickedNodeId
+						}
+						var toKeep = s.graph.neighbors(nodeId);
 				  	toKeep[nodeId] = e.data.node;
 				  	s.graph.nodes().forEach(function(n) {
 				  		if (toKeep[n.id])
@@ -1504,7 +1504,7 @@ if (HTMLWidgets.shinyMode) {
 				  	s.refresh();
 				  });
 				});
-        message.on.split("|").forEach(function(on) {
+				message.on.split("|").forEach(function(on) {
 				  on = on == "overNode" ? "outNode" : "clickStage";
 				  s.bind(on, function(e) {
 					  if (on == "outNode" && clickedNodeId !== null) {

--- a/man/neighbours.Rd
+++ b/man/neighbours.Rd
@@ -11,28 +11,28 @@ sg_neighbours(
   sg,
   nodes = "#eee",
   edges = "#eee",
-  on = c("clickNode", "overNode")
+  on = c("clickNode", "overNode", "clickNode|overNode")
 )
 
 sg_neighbors(
   sg,
   nodes = "#eee",
   edges = "#eee",
-  on = c("clickNode", "overNode")
+  on = c("clickNode", "overNode", "clickNode|overNode")
 )
 
 sg_neighbours_p(
   proxy,
   nodes = "#eee",
   edges = "#eee",
-  on = c("clickNode", "overNode")
+  on = c("clickNode", "overNode", "clickNode|overNode")
 )
 
 sg_neighbors_p(
   proxy,
   nodes = "#eee",
   edges = "#eee",
-  on = c("clickNode", "overNode")
+  on = c("clickNode", "overNode", "clickNode|overNode")
 )
 }
 \arguments{
@@ -42,7 +42,8 @@ sg_neighbors_p(
 
 \item{on}{The sigmajs event on which to trigger the neighbours highlighting.
 'clickNode' (default) means when a node is clicked on. 'overNode' means
-when mouse is hovering on a node.}
+when mouse is hovering on a node. 'clickNode|overNode' means a combination
+of the two modes at the same time.}
 
 \item{proxy}{An object of class \code{sigmajsProxy} as returned by \code{\link{sigmajsProxy}}.}
 }

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -14,7 +14,7 @@ test_that("test init", {
     sg_relative_size()
   
   expect_length(sg$x$settings, 1)
-  expect_length(sg$x$neighbours, 2)
+  expect_length(sg$x$neighbours, 3)
   expect_length(sg$x$noverlap, 0)
   expect_equal(sg$x$relativeSize, 1)
   


### PR DESCRIPTION
This change is a bit more complicated. It enables using both neighbor highlighting on click and neighbor highlighting on mouse over at the same time. Both modes can exist simultaneously.

The diff looks larger than necessary because the indentation was a bit messy and I tried to fit the changes in without indentation jump. I did not manage to get it right, but I think some of the indentation in the file is already mixing tabs and spaces anyway in an unpredictable manner. Feel free to unify code indentation globally.

Cheers!